### PR TITLE
Adding PHP 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 branches:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "pdepend/pdepend": "@stable",
         "sebastian/phpcpd": "@stable",
         "sebastian/phpdcd": "@stable",
-        "squizlabs/php_codesniffer": "@stable"
+        "squizlabs/php_codesniffer": "@stable",
+        "jakub-onderka/php-parallel-lint": "^0.9.2"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require-dev": {
         "phpunit/phpunit": "@stable",
-        "fabpot/php-cs-fixer": "@stable",
+        "friendsofphp/php-cs-fixer": "@stable",
         "phpmd/phpmd": "@stable",
         "phploc/phploc": "@stable",
         "pdepend/pdepend": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,11 @@
         "php": ">=5.4"
     },
     "autoload": {
-        "psr-0": { "DiceCalc\\": "src/" }
+        "psr-4": {
+            "DiceCalc\\": "src/DiceCalc"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {"DiceCalc\\": "tests/DiceCalc"}
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "DiceCalc",
     "version": "1.0.0",
     "keywords": ["dice", "dice calc", "dice calculator", "dice roller"],
+    "license": "MIT",
     "require-dev": {
         "phpunit/phpunit": "@stable",
         "fabpot/php-cs-fixer": "@stable",

--- a/src/DiceCalc/CalcOperation.php
+++ b/src/DiceCalc/CalcOperation.php
@@ -11,6 +11,18 @@ namespace DiceCalc;
  */
 class CalcOperation
 {
+
+    static protected $operators = [
+        '+' => 'add',
+        '*' => 'multiply',
+        '=' => 'equalto',
+        '<' => 'lessthan',
+        '>' => 'greaterthan',
+        '^' => 'exponent',
+        '/' => 'divide',
+        '-' => 'subtract',
+    ];
+
     /**
      * @param  string $operator
      * @param $operand2
@@ -21,18 +33,8 @@ class CalcOperation
      */
     public static function calc($operator, $operand1, $operand2)
     {
-        $operators = [
-            '+' => 'add',
-            '*' => 'multiply',
-            '=' => 'equalto',
-            '<' => 'lessthan',
-            '>' => 'greaterthan',
-            '^' => 'exponent',
-            '/' => 'divide',
-            '-' => 'subtract',
-        ];
-        if(isset($operators[$operator])) {
-            return self::$operators[$operator](self::reduce($operand1), self::reduce($operand2));
+        if(isset(static::$operators[$operator])) {
+            return call_user_func(array('self', static::$operators[$operator]), self::reduce($operand1), self::reduce($operand2));
         }
         throw new \Exception('Unknown operator "' . $operator . '".');
     }

--- a/src/DiceCalc/Random.php
+++ b/src/DiceCalc/Random.php
@@ -19,7 +19,7 @@ class Random {
             $result = $test_fn($min, $max);
         }
         else {
-            $result = rand($min, $max);
+            $result = mt_rand($min, $max);
         }
         return $result;
     }

--- a/src/DiceCalc/Random.php
+++ b/src/DiceCalc/Random.php
@@ -1,14 +1,14 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: owinkler
- * Date: 11/2/14
- * Time: 11:43 PM
- */
 
 namespace DiceCalc;
 
-
+/**
+ * Class Random
+ *
+ * @package DiceCalc
+ * @author  Owen Winkler <epithet@gmail.com>
+ * @license MIT http://opensource.org/licenses/MIT
+ */
 class Random {
     public static $queue = null;
     public static $queue_list = [];


### PR DESCRIPTION
Adding PHP 7 support to Travis CI.
Moving operators array to static variable.
Fixing PHP 7 incompatible static methods calls.
Added License (MIT) to composer file.
Fixed class comments in Random class.
Changed random generating function to better one.
Migrating from PSR-0 to PSR-4 autoloading.
